### PR TITLE
Add CommitResource Tests and Documentation

### DIFF
--- a/src/Resources/CommitResource.md
+++ b/src/Resources/CommitResource.md
@@ -1,3 +1,4 @@
+- Error handling
 # CommitResource
 
 The CommitResource provides access to GitHub's Git commit API endpoints. It allows you to fetch both individual commits and lists of commits for a repository.

--- a/tests/CommitResourceTest.php
+++ b/tests/CommitResourceTest.php
@@ -1,12 +1,11 @@
 <?php
 
+use JordanPartridge\GithubClient\GithubConnector;
 use JordanPartridge\GithubClient\Resources\CommitResource;
-use JordanPartridge\GithubClient\Tests\TestCase;
 use JordanPartridge\GithubClient\ValueObjects\Repo;
 
-uses(TestCase::class);
-
 beforeEach(function () {
+    $this->connector = new GithubConnector;
     $this->resource = new CommitResource($this->connector);
 });
 
@@ -44,6 +43,6 @@ it('handles pagination parameters correctly', function () {
 it('converts repository name to value object correctly', function () {
     $repo = Repo::fromFullName('jordanpartridge/github-client');
 
-    expect($repo->owner)->toBe('jordanpartridge')
-        ->and($repo->name)->toBe('github-client');
+    expect($repo->owner())->toBe('jordanpartridge')
+        ->and($repo->name())->toBe('github-client');
 });


### PR DESCRIPTION
This PR adds comprehensive test coverage for the CommitResource class and detailed documentation.

## Changes Made
- Added `tests/CommitResourceTest.php` with complete test coverage
- Added `src/Resources/CommitResource.md` with detailed API documentation
- Tests cover all main functionality including:
  - Fetching commits list with pagination
  - Fetching specific commits
  - Repository name validation
  - Error handling

## Testing Guidelines Added
- Test cases for all public methods
- Validation testing
- Pagination testing
- Value object conversion testing

## Documentation Added
- Detailed method descriptions
- Code examples
- Parameter documentation
- Error handling information
- Testing guidelines

## Notes for Reviewers
- All tests are written using Pest PHP
- Documentation follows the established pattern
- Error scenarios are properly covered
- Pagination functionality is verified

## Related Issues
- Improves test coverage
- Enhances documentation
- Makes the codebase more maintainable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new resource for accessing GitHub's Git commit API, allowing users to fetch individual and lists of commits for specified repositories.
  - Added functionality for pagination when retrieving multiple commits.
  - Included methods for fetching all commits and specific commits by SHA.

- **Tests**
  - Implemented a comprehensive suite of tests for the new commit resource, covering various functionalities and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->