### PR TITLE
Add Issues support with IssueResource

### DIFF
--- a/src/Resources/IssueResource.php
+++ b/src/Resources/IssueResource.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace JordanPartridge\GithubClient\Resources;
+
+use JordanPartridge\GithubClient\Data\Issue;
+use JordanPartridge\GithubClient\Requests\Issues\CreateIssueRequest;
+use JordanPartridge\GithubClient\Requests\Issues\GetIssueRequest;
+use JordanPartridge\GithubClient\Requests\Issues\ListIssuesRequest;
+use JordanPartridge\GithubClient\Requests\Issues\UpdateIssueRequest;
+use Saloon\Http\Response;
+
+class IssueResource extends BaseResource
+{
+    /**
+     * List issues for a repository
+     *
+     * @param string $repository Repository in format "owner/repo"
+     * @param array $filters Optional filters (state, labels, sort, direction, since)
+     * @return array<Issue>
+     */
+    public function all(string $repository, array $filters = []): array
+    {
+        $response = $this->connector->send(new ListIssuesRequest($repository, $filters));
+
+        return array_map(
+            fn (array $issue) => Issue::from($issue),
+            $response->json()
+        );
+    }
+
+    /**
+     * Get a specific issue
+     *
+     * @param string $repository Repository in format "owner/repo"
+     * @param int $number Issue number
+     * @return Issue
+     */
+    public function get(string $repository, int $number): Issue
+    {
+        $response = $this->connector->send(new GetIssueRequest($repository, $number));
+
+        return Issue::from($response->json());
+    }
+
+    /**
+     * Create a new issue
+     *
+     * @param string $repository Repository in format "owner/repo"
+     * @param string $title Issue title
+     * @param string $body Issue body
+     * @param array $options Additional options (labels, assignees, milestone)
+     * @return Issue
+     */
+    public function create(string $repository, string $title, string $body, array $options = []): Issue
+    {
+        $response = $this->connector->send(new CreateIssueRequest(
+            $repository,
+            $title,
+            $body,
+            $options
+        ));
+
+        return Issue::from($response->json());
+    }
+
+    /**
+     * Update an existing issue
+     *
+     * @param string $repository Repository in format "owner/repo"
+     * @param int $number Issue number
+     * @param array $data Update data (title, body, state, labels, assignees, milestone)
+     * @return Issue
+     */
+    public function update(string $repository, int $number, array $data): Issue
+    {
+        $response = $this->connector->send(new UpdateIssueRequest(
+            $repository,
+            $number,
+            $data
+        ));
+
+        return Issue::from($response->json());
+    }
+}

--- a/src/Resources/IssueResource.php
+++ b/src/Resources/IssueResource.php
@@ -7,15 +7,14 @@ use JordanPartridge\GithubClient\Requests\Issues\CreateIssueRequest;
 use JordanPartridge\GithubClient\Requests\Issues\GetIssueRequest;
 use JordanPartridge\GithubClient\Requests\Issues\ListIssuesRequest;
 use JordanPartridge\GithubClient\Requests\Issues\UpdateIssueRequest;
-use Saloon\Http\Response;
 
 class IssueResource extends BaseResource
 {
     /**
      * List issues for a repository
      *
-     * @param string $repository Repository in format "owner/repo"
-     * @param array $filters Optional filters (state, labels, sort, direction, since)
+     * @param  string  $repository  Repository in format "owner/repo"
+     * @param  array  $filters  Optional filters (state, labels, sort, direction, since)
      * @return array<Issue>
      */
     public function all(string $repository, array $filters = []): array
@@ -31,9 +30,8 @@ class IssueResource extends BaseResource
     /**
      * Get a specific issue
      *
-     * @param string $repository Repository in format "owner/repo"
-     * @param int $number Issue number
-     * @return Issue
+     * @param  string  $repository  Repository in format "owner/repo"
+     * @param  int  $number  Issue number
      */
     public function get(string $repository, int $number): Issue
     {
@@ -45,11 +43,10 @@ class IssueResource extends BaseResource
     /**
      * Create a new issue
      *
-     * @param string $repository Repository in format "owner/repo"
-     * @param string $title Issue title
-     * @param string $body Issue body
-     * @param array $options Additional options (labels, assignees, milestone)
-     * @return Issue
+     * @param  string  $repository  Repository in format "owner/repo"
+     * @param  string  $title  Issue title
+     * @param  string  $body  Issue body
+     * @param  array  $options  Additional options (labels, assignees, milestone)
      */
     public function create(string $repository, string $title, string $body, array $options = []): Issue
     {
@@ -66,10 +63,9 @@ class IssueResource extends BaseResource
     /**
      * Update an existing issue
      *
-     * @param string $repository Repository in format "owner/repo"
-     * @param int $number Issue number
-     * @param array $data Update data (title, body, state, labels, assignees, milestone)
-     * @return Issue
+     * @param  string  $repository  Repository in format "owner/repo"
+     * @param  int  $number  Issue number
+     * @param  array  $data  Update data (title, body, state, labels, assignees, milestone)
      */
     public function update(string $repository, int $number, array $data): Issue
     {


### PR DESCRIPTION
## Summary
Adds comprehensive GitHub Issues support to the client.

## Features Added
- 📋 **IssueResource** with full CRUD operations
- 🔍 **List issues** with filtering (state, labels, sort, direction, since)
- 📝 **Create issues** with full option support
- 👁️ **Get specific issues** by number  
- ✏️ **Update issues** with comprehensive data support
- 🎯 **Proper DTOs** using Issue::from() pattern

## Request Classes
- ListIssuesRequest
- GetIssueRequest  
- CreateIssueRequest
- UpdateIssueRequest

## Usage
```php
// List issues
$issues = $github->issues()->all('owner/repo', ['state' => 'open']);

// Create issue
$issue = $github->issues()->create('owner/repo', 'Bug Report', 'Description here');

// Get specific issue
$issue = $github->issues()->get('owner/repo', 123);
```

This enables full GitHub Issues management in the client and provides the foundation for GitHub Zero CLI issue commands.