### PR TITLE
ci: Drop Laravel 10, add PHP 8.4, upgrade checkout v6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,21 +13,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3]
-        laravel: [10.*, 11.*, 12.*]
-        experimental: [false]
+        # Laravel 10 EOL: Feb 4, 2025 - dropped from test matrix
+        # See: https://laravel.com/docs/12.x/releases#support-policy
+        php: [8.2, 8.3, 8.4]
+        laravel: [11.*, 12.*]
         stability: [prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
         exclude:
           # Laravel 12 requires PHP 8.3+
           - php: 8.2
@@ -37,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -46,40 +44,13 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
           tools: composer:v2
           coverage: none
-          ini-values: memory_limit=512M
-
-      - name: Setup problem matchers
-        run: |
-          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
         run: |
-          # Remove conflicting dependencies
           composer remove --dev --no-update larastan/larastan phpstan/phpstan-deprecation-rules phpstan/phpstan-phpunit phpstan/extension-installer
-          
-          # Configure Laravel version
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          
-          # Handle collision version compatibility
-          if [[ "${{ matrix.laravel }}" == "10.*" ]]; then
-            composer require --dev --no-update "nunomaduro/collision:^7.0"
-          elif [[ "${{ matrix.laravel }}" == "11.*" || "${{ matrix.laravel }}" == "12.*" ]]; then
-            composer require --dev --no-update "nunomaduro/collision:^8.0"
-          fi
-          
-          # Handle Carbon version for Laravel 12
-          if [[ "${{ matrix.laravel }}" == "12.*" ]]; then
-            composer require --no-update "nesbot/carbon:^3.0"
-          elif [[ "${{ matrix.laravel }}" == "10.*" || "${{ matrix.laravel }}" == "11.*" ]]; then
-            composer require --no-update "nesbot/carbon:^2.63"
-          fi
-          
-          # Install dependencies
+          composer require --dev --no-update "nunomaduro/collision:^8.0"
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction --with-all-dependencies
-
-      - name: List Installed Dependencies
-        run: composer show
 
       - name: Execute tests
         run: vendor/bin/pest


### PR DESCRIPTION
## Summary
- Remove Laravel 10 from test matrix (EOL Feb 4, 2025)
- Add PHP 8.4 to test matrix  
- Upgrade actions/checkout v4 → v6

## Why?

### Laravel 10 EOL
Laravel 10 reached end-of-life on **February 4, 2025**.
📚 https://laravel.com/docs/12.x/releases#support-policy

### PHP 8.4 Support
PHP 8.4 is the current stable version (Nov 2024).
📚 https://www.php.net/supported-versions.php

### actions/checkout v6
Improved credential handling and Node.js 24 support.
📚 https://github.com/actions/checkout/releases/tag/v6.0.0

## Breaking Change
Part of upcoming major release. Laravel 10 users should stay on current version.

Closes #107, supersedes #105

Co-Authored-By: ci-updater <ci-updater@the-shit.bot>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Updated CI/CD testing matrix to support PHP 8.4
* Dropped Laravel 10 from supported test versions; now tests against Laravel 11.* and 12.*
* Streamlined dependency installation and workflow setup process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->